### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Create a release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/NexusPHP/cs-config/security/code-scanning/1](https://github.com/NexusPHP/cs-config/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the job level. The `permissions` block will specify the minimum necessary privileges for the workflow to function correctly. In this case, the job requires `contents: read` to read the repository contents and `contents: write` to create a release. These permissions should be applied directly to the job where actions are executed.

The `permissions` block will be added under the `jobs.build` section of the `.github/workflows/release.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
