### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: build
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 0 * * *'
@@ -91,12 +94,3 @@ jobs:
 
   coveralls-finish:
     name: Coveralls Finished
-    needs: [main]
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Upload to Coveralls API
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,3 +94,14 @@ jobs:
 
   coveralls-finish:
     name: Coveralls Finished
+    needs: [main]
+    permissions:
+      actions: write
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Upload to Coveralls API
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
Potential fix for [https://github.com/NexusPHP/cs-config/security/code-scanning/2](https://github.com/NexusPHP/cs-config/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the workflow that limits the `GITHUB_TOKEN` permissions to only those required by the jobs. This can be done at the root of the workflow, so it applies to all jobs, or within the `main` and `coveralls-finish` jobs to specify permissions granularly.

For this workflow:
- The `main` job primarily uses read-only permissions to check out code, validate dependencies, run tests, and upload reports.
- The `coveralls-finish` job requires write access to upload results to Coveralls.

Add the following permissions:
- `contents: read` for the `main` job, as it needs access to repository code but does not modify it.
- `contents: read` and `actions: write` for the `coveralls-finish` job, as it uploads results to Coveralls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
